### PR TITLE
Center player over Tube, Tree when caught in collision vortex

### DIFF
--- a/assets/js/platformer3x/Character.js
+++ b/assets/js/platformer3x/Character.js
@@ -23,7 +23,7 @@ class Character extends GameObject {
     }
 
     getMinFrame(){
-        return this.manFrame;
+        return this.minFrame;
     }
 
     setMinFrame(minFrame){
@@ -136,7 +136,7 @@ class Character extends GameObject {
         if (this.frameX < this.maxFrame) {
             this.frameX++;
         } else {
-            this.frameX = 0;
+            this.frameX = this.minFrame;
         }
 
         this.collisionChecks();

--- a/assets/js/platformer3x/GameObject.js
+++ b/assets/js/platformer3x/GameObject.js
@@ -157,9 +157,11 @@ class GameObject {
     
         // Calculate center points of rectangles
         const thisCenterX = (thisRect.left + thisRect.right) / 2;
-        //const thisCenterY = (thisRect.top + thisRect.bottom) / 2;
         const otherCenterX = (otherRect.left + otherRect.right) / 2;
-        //const otherCenterY = (otherRect.top + otherRect.bottom) / 2;
+
+        // Calculate new center points of rectangles
+        const thisRectWidth = thisRect.right - thisRect.left;
+        const thisRectLeftNew = otherCenterX - thisRectWidth / 2;
     
         // Calculate hitbox constants
         var widthPercentage = this.widthPercentage;
@@ -187,6 +189,7 @@ class GameObject {
     
         // Determine hit and touch points of hit
         this.collisionData = {
+            newX: thisRectLeftNew, // proportionally adjust left to center over other object
             hit: (
                 thisLeft < otherRect.right &&
                 thisRight > otherRect.left &&
@@ -208,7 +211,6 @@ class GameObject {
                     bottom: (thisRect.bottom >= otherRect.top) && !(Math.abs(thisRect.bottom - otherRect.bottom) <= GameEnv.gravity),
                     left: thisCenterX < otherCenterX, 
                     right: thisCenterX > otherCenterX,
-                    x: otherRect.left,
                 },
             },
         };

--- a/assets/js/platformer3x/GameSetup.js
+++ b/assets/js/platformer3x/GameSetup.js
@@ -208,7 +208,6 @@ const GameSetup = {
           height: 256,
           scaleSize: 80,
           speedRatio: 0.7,
-          w: { row: 10, frames: 15 },
           wa: { row: 11, frames: 15 },
           wd: { row: 10, frames: 15 },
           a: { row: 3, frames: 7, idleFrame: { column: 7, frames: 0 } },
@@ -221,9 +220,8 @@ const GameSetup = {
           height: 40,
           scaleSize: 80,
           speedRatio: 0.7,
-          w: { row: 9, frames: 15 },
-          wa: { row: 9, frames: 15 },
-          wd: { row: 9, frames: 15 },
+          wa: { row: 9, min: 8, frames: 15 },
+          wd: { row: 9, min: 0, frames: 7 },
           a: { row: 1, frames: 15, idleFrame: { column: 7, frames: 0 } },
           s: { row: 12, frames: 15 },
           d: { row: 0, frames: 15, idleFrame: { column: 7, frames: 0 } }
@@ -234,7 +232,6 @@ const GameSetup = {
           height: 52.5,
           scaleSize: 60,
           speedRatio: 0.7,
-          w: {row: 1, frames: 3}, // Up Movement
           wa: {row: 1, frames: 3}, // Up-Left Movement 
           wd: {row: 2, frames: 3}, // Up-Right Movement
           idle: { row: 6, frames: 1, idleFrame: {column: 1, frames: 0} },

--- a/assets/js/platformer3x/Player.js
+++ b/assets/js/platformer3x/Player.js
@@ -105,8 +105,6 @@ export class Player extends Character {
      * @param {string} key - The key representing the animation to set.
      */
     setAnimation(key) {
-        // animation comes from playerData
-        var animation = this.playerData[key]
         // direction setup
         if (this.isKeyActionLeft(key)) {
             this.directionKey = key;
@@ -115,8 +113,11 @@ export class Player extends Character {
             this.directionKey = key;
             this.playerData.w = this.playerData.wd;
         }
+        // animation comes from playerData
+        var animation = this.playerData[key]
         // set frame and idle frame
         this.setFrameY(animation.row);
+        this.setMinFrame(animation.min ? animation.min : 0);
         this.setMaxFrame(animation.frames);
         if (this.isIdle && animation.idleFrame) {
             this.setFrameX(animation.idleFrame.column)
@@ -377,7 +378,6 @@ export class Player extends Character {
             if (event.key in this.pressedKeys) {
                 delete this.pressedKeys[event.key];
             }
-            this.setAnimation(key);  
             // player idle
             this.isIdle = true;
             // dash action off

--- a/assets/js/platformer3x/Player.js
+++ b/assets/js/platformer3x/Player.js
@@ -229,7 +229,9 @@ export class Player extends Character {
      */
     collisionAction() {
         // Tube collision check
-        if (this.collisionData.touchPoints.other.id === "tube") {
+        if (this.collisionData.touchPoints.other.id === "tube" 
+            || this.collisionData.touchPoints.other.id === "tree") {
+
             // Collision with the left side of the Tube
             if (this.collisionData.touchPoints.other.left) {
                 this.movement.right = false;
@@ -240,7 +242,7 @@ export class Player extends Character {
             }
             // Collision with the top of the player
             if (this.collisionData.touchPoints.other.bottom) {
-                this.x = this.collisionData.touchPoints.other.x;
+                this.x = this.collisionData.newX;
                 this.gravityEnabled = false; // stop gravity
                 // Pause for two seconds
                 setTimeout(() => {   // animation in tube for 1 seconds
@@ -252,34 +254,6 @@ export class Player extends Character {
             }
         } else {
             // Reset movement flags if not colliding with a tube
-            this.movement.left = true;
-            this.movement.right = true;
-        }
-
-        // Tree collision check
-        if (this.collisionData.touchPoints.other.id === "tree") {
-            // Collision with the left side of the tree
-            if (this.collisionData.touchPoints.other.left) {
-                this.movement.right = false;
-            }
-            // Collision with the right side of the tree
-            if (this.collisionData.touchPoints.other.right) {
-                this.movement.left = false;
-            }
-            // Collision with the top of the player
-            if (this.collisionData.touchPoints.other.bottom) {
-                this.x = this.collisionData.touchPoints.other.x;
-                this.gravityEnabled = false; // stop gravity
-                // Pause for two seconds
-                setTimeout(() => {   
-                    this.gravityEnabled = true;
-                    setTimeout(() => { // move to end of screen for end of game detection
-                        this.x = GameEnv.innerWidth + 1;
-                    }, 500);
-                }, 500);
-            }
-        } else {
-            // Reset movement flags if not colliding with a tree
             this.movement.left = true;
             this.movement.right = true;
         }
@@ -308,11 +282,6 @@ export class Player extends Character {
                 this.canvas.style.filter = 'invert(0)';
             }, 2000); // 2000 milliseconds = 2 seconds
         }
-
-        //if (GameEnv.destroyedMushroom === true) {
-            //GameEnv.playMessage = true;
-        //}
-         
 
         if (this.collisionData.touchPoints.other.id === "jumpPlatform") {
             if (this.collisionData.touchPoints.other.left) {


### PR DESCRIPTION
## Description of Issue
This is to fix the issue where Lopez does not center in tube on jump to end game.

![image](https://github.com/jm1021/platformer3x/assets/54686997/8c15e861-4a37-40e5-bbe7-9ae3964bdc9b)

### New Look samples
This fix makes the Lopez and Monkey look like there jumps are appropriately centered.  However, as both reach the floor they seem to appear to the left of automatic centering.  This is another issue to code fix.

![image](https://github.com/jm1021/platformer3x/assets/54686997/f66f0388-8ec7-4e5c-a162-4f7c51007657)

![image](https://github.com/jm1021/platformer3x/assets/54686997/9ef9547a-0438-4434-ac18-50ad8374ddee)

### Sample code fix
The x position needed to be adjusted to be offset from center of obstacle, not the same as obstacles x position.
This fix  was made in collision code.  The only reason Mario looked OK is because sprite width of Tube and Mario were similar.   This was not the case with Lopez and the Monkey.

- GameObject.js.   Fix math to find proportional x to be related to center of other object.
- Player.js.  Relocate Player when in vortex of obstacle to move its x position to proportional x
