### PR TITLE
Fix going through block on Quidditch level

### DIFF
--- a/assets/js/platformer3x/PlayerBase.js
+++ b/assets/js/platformer3x/PlayerBase.js
@@ -327,18 +327,18 @@ export class PlayerBase extends Character {
             // 1. Player is on a jump platform
             case "jumpPlatform":
                 // Player is on top of the jump platform
-                if (this.collisionData.touchPoints.this.onTopofPlatform) {
-                    this.state.movement = { up: false, down: false, left: true, right: true, falling: false};
-                    this.gravityEnabled = false;
-                } else if (this.collisionData.touchPoints.this.right) {
+                if (this.collisionData.touchPoints.this.right) {
                     this.state.movement = { up: false, down: false, left: true, right: false, falling: false};
                     this.y -= 4;
-
-                // Player is touching the wall with left side
+                    // Player is touching the wall with left side
                 } else if (this.collisionData.touchPoints.this.left) {
                     this.state.movement = { up: false, down: false, left: false, right: true, falling: false};
                     this.y -= 4;
+                } else if (this.collisionData.touchPoints.this.onTopofPlatform) {
+                    this.state.movement = { up: false, down: false, left: true, right: true, falling: false};
+                    this.gravityEnabled = false;
                 }
+                
             
 
                 break;


### PR DESCRIPTION
Walking through the platform has been fixed

Code Changed:

```
case "jumpPlatform":
                // Player is on top of the jump platform
                if (this.collisionData.touchPoints.this.right) {
                    this.state.movement = { up: false, down: false, left: true, right: false, falling: false};
                    this.y -= 4;
                    // Player is touching the wall with left side
                } else if (this.collisionData.touchPoints.this.left) {
                    this.state.movement = { up: false, down: false, left: false, right: true, falling: false};
                    this.y -= 4;
                } else if (this.collisionData.touchPoints.this.onTopofPlatform) {
                    this.state.movement = { up: false, down: false, left: true, right: true, falling: false};
                    this.gravityEnabled = false;
                }
```